### PR TITLE
allow Django like template SQL

### DIFF
--- a/cmd/mysqlbatch/main.go
+++ b/cmd/mysqlbatch/main.go
@@ -32,6 +32,7 @@ func main() {
 		silentFlag          = flag.Bool("s", false, "no output to console")
 		detailFlag          = flag.Bool("d", false, "output deteil for execute sql, -s has priority")
 		enableBootstrapFlag = flag.Bool("enable-lambda-bootstrap", false, "if run on AWS Lambda, running as lambda bootstrap")
+		dumpRenderedSQLFlag = flag.Bool("dump-rendered-sql", false, "dump rendered sql")
 	)
 	flag.StringVar(&conf.DSN, "dsn", "", "dsn format as [mysql://]user:pass@tcp(host:port)/dbname (default \"\")")
 	flag.StringVar(&conf.User, "u", "root", "username (default root)")
@@ -53,6 +54,9 @@ func main() {
 		fmt.Printf("go version: %s\n", runtime.Version())
 		fmt.Printf("build date: %s\n", BuildDate)
 		return
+	}
+	if *dumpRenderedSQLFlag {
+		mysqlbatch.DefaultSQLDumper = os.Stderr
 	}
 	conf.Database = os.Getenv("MYSQLBATCH_DATABASE")
 	if flag.NArg() == 1 {

--- a/executer.go
+++ b/executer.go
@@ -101,42 +101,40 @@ func (e *Executer) executeContext(ctx context.Context, queryReader io.Reader, va
 		if query == "" {
 			continue
 		}
-		if vars != nil {
-			tpl, err := template.New("query").Funcs(template.FuncMap{
-				"var": func(key string, defaultValue string) string {
-					if v, ok := vars[key]; ok {
-						return v
-					}
-					return defaultValue
-				},
-				"must_var": func(key string) (string, error) {
-					if v, ok := vars[key]; ok {
-						return v, nil
-					}
-					return "", errors.Errorf("variable %s is not defined", key)
-				},
-				"env": func(key string, defaultValue string) string {
-					if v := os.Getenv(key); v != "" {
-						return v
-					}
-					return defaultValue
-				},
-				"must_env": func(key string) (string, error) {
-					if v, ok := os.LookupEnv(key); ok {
-						return v, nil
-					}
-					return "", errors.Errorf("environment variable %s is not defined", key)
-				},
-			}).Parse(query)
-			if err != nil {
-				return errors.Wrap(err, "parse query template failed")
-			}
-			var buf strings.Builder
-			if err := tpl.Execute(&buf, nil); err != nil {
-				return errors.Wrap(err, "execute query template failed")
-			}
-			query = buf.String()
+		tpl, err := template.New("query").Funcs(template.FuncMap{
+			"var": func(key string, defaultValue string) string {
+				if v, ok := vars[key]; ok {
+					return v
+				}
+				return defaultValue
+			},
+			"must_var": func(key string) (string, error) {
+				if v, ok := vars[key]; ok {
+					return v, nil
+				}
+				return "", errors.Errorf("variable %s is not defined", key)
+			},
+			"env": func(key string, defaultValue string) string {
+				if v := os.Getenv(key); v != "" {
+					return v
+				}
+				return defaultValue
+			},
+			"must_env": func(key string) (string, error) {
+				if v, ok := os.LookupEnv(key); ok {
+					return v, nil
+				}
+				return "", errors.Errorf("environment variable %s is not defined", key)
+			},
+		}).Parse(query)
+		if err != nil {
+			return errors.Wrap(err, "parse query template failed")
 		}
+		var buf strings.Builder
+		if err := tpl.Execute(&buf, nil); err != nil {
+			return errors.Wrap(err, "execute query template failed")
+		}
+		query = buf.String()
 		if e.selectHook != nil {
 			upperedQuery := strings.ToUpper(query)
 			var isSelect bool

--- a/executer_test.go
+++ b/executer_test.go
@@ -125,6 +125,7 @@ func TestExecuterExecute(t *testing.T) {
 
 func TestExecuterExecute__WithVars(t *testing.T) {
 	os.Setenv("ENV", "test")
+	mysqlbatch.DefaultSQLDumper = os.Stderr
 	conf := mysqlbatch.NewDefaultConfig()
 	conf.Password = "mysqlbatch"
 	conf.Location = "Asia/Tokyo"

--- a/executer_test.go
+++ b/executer_test.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -94,6 +95,9 @@ func diffStr(a, b string) (string, bool) {
 //go:embed testdata/test.sql
 var testSQL []byte
 
+//go:embed testdata/test_template.sql
+var testTemplateSQL []byte
+
 func TestExecuterExecute(t *testing.T) {
 	conf := mysqlbatch.NewDefaultConfig()
 	conf.Password = "mysqlbatch"
@@ -112,7 +116,36 @@ func TestExecuterExecute(t *testing.T) {
 		require.Equal(t, `SELECT * FROM users WHERE age is NOT NULL LIMIT 5`, query)
 		require.Equal(t, 5, len(rows))
 	})
-	err = e.Execute(bytes.NewReader(testSQL))
+	err = e.Execute(bytes.NewReader(testSQL), nil)
+	require.NoError(t, err)
+	log.Println("LastExecuteTime:", e.LastExecuteTime())
+	require.InDelta(t, time.Since(e.LastExecuteTime()), 0, float64(5*time.Minute))
+	require.EqualValues(t, 1, count)
+}
+
+func TestExecuterExecute__WithVars(t *testing.T) {
+	os.Setenv("ENV", "test")
+	conf := mysqlbatch.NewDefaultConfig()
+	conf.Password = "mysqlbatch"
+	conf.Location = "Asia/Tokyo"
+	e, err := mysqlbatch.New(context.Background(), conf)
+	require.NoError(t, err)
+	defer e.Close()
+
+	e.SetTimeCheckQuery("SELECT NOW()")
+	e.SetTableSelectHook(func(query, table string) {
+		t.Log(query + "\n" + table + "\n")
+	})
+	var count int32
+	e.SetSelectHook(func(query string, columns []string, rows [][]string) {
+		atomic.AddInt32(&count, 1)
+		require.Equal(t, `SELECT * FROM users WHERE age is NOT NULL LIMIT 5`, query)
+		require.Equal(t, 5, len(rows))
+	})
+	err = e.Execute(bytes.NewReader(testTemplateSQL), map[string]string{
+		"relation": "users",
+		"limit":    "5",
+	})
 	require.NoError(t, err)
 	log.Println("LastExecuteTime:", e.LastExecuteTime())
 	require.InDelta(t, time.Since(e.LastExecuteTime()), 0, float64(5*time.Minute))

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.25
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.0
 	github.com/aws/smithy-go v1.13.5
+	github.com/flosch/pongo2/v6 v6.0.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/ken39arg/go-flagx v0.0.0-20220608183922-7cf7c6c0093c
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/flosch/pongo2/v6 v6.0.0 h1:lsGru8IAzHgIAw6H2m4PCyleO58I40ow6apih0WprMU=
+github.com/flosch/pongo2/v6 v6.0.0/go.mod h1:CuDpFm47R0uGGE7z13/tTlt1Y6zdxvr2RLT5LJhsHEU=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
@@ -44,8 +46,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/ken39arg/go-flagx v0.0.0-20220608183922-7cf7c6c0093c h1:jrKp5SY9Qt8lQmorJAksSYOIexZdkp7EREJgx4mX9XA=
 github.com/ken39arg/go-flagx v0.0.0-20220608183922-7cf7c6c0093c/go.mod h1:DNbx2/OnOT5GtlYTUF2xr4GZSunGDP1Wk0WO3mmaKz0=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -74,8 +76,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/testdata/test_template.sql
+++ b/testdata/test_template.sql
@@ -1,17 +1,17 @@
-CREATE DATABASE IF NOT EXISTS {{ must_env `ENV` }}_mysqlbatch;
-USE {{ must_env `ENV` }}_mysqlbatch;
-DROP TABLE IF EXISTS {{ var `relation` `hoge` }};
-CREATE TABLE {{ var `relation` `hoge` }} (
+CREATE DATABASE IF NOT EXISTS {{ must_env("ENV") }}_mysqlbatch;
+USE {{ must_env("ENV") }}_mysqlbatch;
+DROP TABLE IF EXISTS {{ var("relation","hoge") }};
+CREATE TABLE {{ var("relation","hoge") }} (
     id INTEGER auto_increment,
     name VARCHAR(191),
     age INTEGER,
     PRIMARY KEY (`id`),
     UNIQUE INDEX `name` (`name`)
 );
-INSERT IGNORE INTO {{ var `relation` `hoge` }}(name) VALUES(CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com'));
-INSERT IGNORE INTO {{ var `relation` `hoge` }}(name) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')) FROM {{ var `relation` `hoge` }};
-INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
-INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
-INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
-SELECT * FROM {{ var `relation` `hoge` }} WHERE age is NOT NULL LIMIT {{ must_var `limit` }};
+INSERT IGNORE INTO {{ var("relation","hoge") }}(name) VALUES(CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com'));
+INSERT IGNORE INTO {{ var("relation","hoge") }}(name) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')) FROM {{ var("relation","hoge") }};
+{%- for i in range(3) %}
+INSERT IGNORE INTO {{ var("relation","hoge") }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var("relation","hoge") }};
+{%- endfor %}
+SELECT * FROM {{ var("relation","hoge") }} WHERE age is NOT NULL LIMIT {{ must_var("limit") }};
 

--- a/testdata/test_template.sql
+++ b/testdata/test_template.sql
@@ -1,0 +1,17 @@
+CREATE DATABASE IF NOT EXISTS {{ must_env `ENV` }}_mysqlbatch;
+USE {{ must_env `ENV` }}_mysqlbatch;
+DROP TABLE IF EXISTS {{ var `relation` `hoge` }};
+CREATE TABLE {{ var `relation` `hoge` }} (
+    id INTEGER auto_increment,
+    name VARCHAR(191),
+    age INTEGER,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `name` (`name`)
+);
+INSERT IGNORE INTO {{ var `relation` `hoge` }}(name) VALUES(CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com'));
+INSERT IGNORE INTO {{ var `relation` `hoge` }}(name) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')) FROM {{ var `relation` `hoge` }};
+INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
+INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
+INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
+SELECT * FROM {{ var `relation` `hoge` }} WHERE age is NOT NULL LIMIT {{ must_var `limit` }};
+


### PR DESCRIPTION
It seems that there is a need to templateize the SQL specified in task.
So, although it is simple, it can be templateized with Go Tamplate.
For the time being, we will not use a complicated template engine that can define macros.

example
```sql
CREATE DATABASE IF NOT EXISTS {{ must_env `ENV` }}_mysqlbatch;
USE {{ must_env `ENV` }}_mysqlbatch;
DROP TABLE IF EXISTS {{ var `relation` `hoge` }};
CREATE TABLE {{ var `relation` `hoge` }} (
    id INTEGER auto_increment,
    name VARCHAR(191),
    age INTEGER,
    PRIMARY KEY (`id`),
    UNIQUE INDEX `name` (`name`)
);
INSERT IGNORE INTO {{ var `relation` `hoge` }}(name) VALUES(CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com'));
INSERT IGNORE INTO {{ var `relation` `hoge` }}(name) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')) FROM {{ var `relation` `hoge` }};
INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
INSERT IGNORE INTO {{ var `relation` `hoge` }}(name, age) SELECT (CONCAT(SUBSTRING(MD5(RAND()), 1, 40),'@example.com')),RAND() FROM {{ var `relation` `hoge` }};
SELECT * FROM {{ var `relation` `hoge` }} WHERE age is NOT NULL LIMIT {{ must_var `limit` }};
```

```
$ go run cmd/mysqlbatch/main.go -h 127.0.0.1 --port 3306 -p mysqlbatch < testdata/test_template.sql --var limit=5 --var relation=hoge
2023/05/29 16:30:16 SELECT * FROM hoge WHERE age is NOT NULL LIMIT 5
+----+----------------------------------------------+-----+
| ID |                     NAME                     | AGE |
+----+----------------------------------------------+-----+
|  3 | 6b2d194aa6dfbe5886f089370c495af1@example.com |   1 |
|  4 | a998323e72b5582cf86c260f4d5c0f0a@example.com |   0 |
|  6 | 14c5b540fae3b60c26e703aaf58b4e13@example.com |   1 |
|  7 | cec2abd710bbce6cc899099d529b47b6@example.com |   1 |
|  8 | 17ac7a29e132612c2964ba2d78f7a3ca@example.com |   0 |
+----+----------------------------------------------+-----+


2023/05/29 16:30:16 DB time when the last SQL was executed: 2023-05-29 16:30:16 +0000 UTC
```