### PR TITLE
add MYSQLBATCH_PASSWORD_SSM_PARAMETER_JSON_KEY 

### DIFF
--- a/cmd/mysqlbatch/main.go
+++ b/cmd/mysqlbatch/main.go
@@ -45,6 +45,7 @@ func main() {
 	flag.StringVar(&conf.Host, "host", "", "")
 	flag.StringVar(&conf.Location, "location", "", "timezone of mysql database system")
 	flag.StringVar(&conf.PasswordSSMParameterName, "password-ssm-parameter-name", "", "pasword ssm parameter name")
+	flag.StringVar(&conf.PasswordSSMParameterJSONKey, "password-ssm-parameter-json-key", "", "pasword ssm parameter json key")
 	flag.Var(&vars, "var", "set variable (format: key=value)")
 	flag.VisitAll(flagx.EnvToFlagWithPrefix("MYSQLBATCH_"))
 	flag.Parse()

--- a/config_test.go
+++ b/config_test.go
@@ -2,11 +2,13 @@ package mysqlbatch_test
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Songmu/flextime"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
@@ -45,26 +47,77 @@ func TestSSMParameterFetcher(t *testing.T) {
 	now := time.Now()
 	restore := flextime.Fix(now)
 	defer restore()
-	actual, err := fetcher.Fetch(context.Background(), "/test/DBPASSWORD")
+	actual, err := fetcher.Fetch(context.Background(), "/test/DBPASSWORD", "passowrd")
 	require.NoError(t, err)
 	require.Equal(t, "test password", actual)
 	require.EqualValues(t, 1, apiCallCount)
 
 	remotePassword = "test password2"
 	flextime.Fix(now.Add(5 * time.Minute))
-	actual, err = fetcher.Fetch(context.Background(), "/test/DBPASSWORD")
+	actual, err = fetcher.Fetch(context.Background(), "/test/DBPASSWORD", "")
 	require.NoError(t, err)
 	require.Equal(t, "test password", actual)
 	require.EqualValues(t, 1, apiCallCount)
 
-	actual, err = fetcher.Fetch(context.Background(), "/test2/DBPASSWORD")
+	actual, err = fetcher.Fetch(context.Background(), "/test2/DBPASSWORD", "")
 	require.NoError(t, err)
 	require.Equal(t, "test password2", actual)
 	require.EqualValues(t, 2, apiCallCount)
 
 	flextime.Fix(now.Add(20 * time.Minute))
-	actual, err = fetcher.Fetch(context.Background(), "/test/DBPASSWORD")
+	actual, err = fetcher.Fetch(context.Background(), "/test/DBPASSWORD", "")
 	require.NoError(t, err)
 	require.Equal(t, "test password2", actual)
-	require.EqualValues(t, 3, apiCallCount)
+	require.EqualValues(t, int32(3), apiCallCount)
+}
+
+func TestSSMParameterFetcher__JSON(t *testing.T) {
+	var apiCallCount int32
+	remotePassword := "test password"
+	fetcher := &mysqlbatch.SSMParameterFetcher{
+		LoadAWSDefaultConfigOptions: []func(*config.LoadOptions) error{
+			config.WithRegion("ap-northeast-1"),
+			config.WithAPIOptions([]func(stack *middleware.Stack) error{
+				func(stack *middleware.Stack) error {
+					return stack.Finalize.Add(
+						middleware.FinalizeMiddlewareFunc("test",
+							func(context.Context, middleware.FinalizeInput, middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+								atomic.AddInt32(&apiCallCount, 1)
+								return middleware.FinalizeOutput{
+									Result: &ssm.GetParameterOutput{
+										Parameter: &types.Parameter{
+											Value: aws.String(
+												fmt.Sprintf(`{"password":"%s", "name":"hoge", "port":3306}`, remotePassword),
+											),
+										},
+									},
+								}, middleware.Metadata{}, nil
+							},
+						),
+						middleware.Before,
+					)
+				},
+			}),
+		},
+	}
+	now := time.Now()
+	restore := flextime.Fix(now)
+	defer restore()
+	actual, err := fetcher.Fetch(context.Background(), "/test/DBPASSWORD", "password")
+	require.NoError(t, err)
+	require.Equal(t, "test password", actual)
+	require.EqualValues(t, 1, apiCallCount)
+
+	remotePassword = "test password2"
+	flextime.Fix(now.Add(5 * time.Minute))
+	actual, err = fetcher.Fetch(context.Background(), "/test/DBPASSWORD", "password")
+	require.NoError(t, err)
+	require.Equal(t, "test password", actual)
+	require.EqualValues(t, 1, apiCallCount)
+
+	flextime.Fix(now.Add(20 * time.Minute))
+	actual, err = fetcher.Fetch(context.Background(), "/test/DBPASSWORD", "password")
+	require.NoError(t, err)
+	require.Equal(t, "test password2", actual)
+	require.EqualValues(t, int32(2), apiCallCount)
 }

--- a/executer.go
+++ b/executer.go
@@ -228,7 +228,7 @@ func (e *Executer) SetTableSelectHook(hook func(query, table string)) {
 	}
 }
 
-func (e *Executer) newPongo2Ctx(ctx context.Context, vars map[string]string) pongo2.Context {
+func (e *Executer) newPongo2Ctx(_ context.Context, vars map[string]string) pongo2.Context {
 	pongo2Ctx := pongo2.Context{
 		"var": func(key string, defaultValue string) string {
 			if v, ok := vars[key]; ok {


### PR DESCRIPTION
Currently there is a function to obtain DB Password via SSM Parameter.
This can be obtained by specifying the SSM Parameter Name in MYSQLBATCH_PASSWORD_SSM_PARAMETER_NAME.

By the way, there is a function to get Secrets Manager via SSM Paramter.
https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/integration-ps-secretsmanager.html

for example:

```
MYSQLBATCH_PASSWORD_SSM_PARAMETER_NAME=/aws/reference/secretsmanager/db-password
```


Secrets Manager often stores connection information in JSON, so there are cases where you may want to use only the key specified in JSON from the connection information obtained.